### PR TITLE
Rebase on v0.8.9

### DIFF
--- a/codecs/vp9_packet.go
+++ b/codecs/vp9_packet.go
@@ -435,7 +435,7 @@ func (p *VP9Packet) parseSSData(packet []byte, pos int) (int, error) {
 
 	p.NS = packet[pos] >> 5
 	p.Y = packet[pos]&0x10 != 0
-	p.G = (packet[pos]>>1)&0x7 != 0
+	p.G = packet[pos]&0x8 != 0
 	pos++
 
 	NS := p.NS + 1

--- a/codecs/vp9_packet_test.go
+++ b/codecs/vp9_packet_test.go
@@ -169,6 +169,25 @@ func TestVP9Packet_Unmarshal(t *testing.T) {
 				Payload: []byte{},
 			},
 		},
+		"ScalabilityStructureReserved": {
+			b: []byte{
+				0x0A,
+				(1 << 5) | (0 << 4) | (0 << 3) | (1 << 2) | (1 << 1) | 1, // NS:1 Y:0 G:0, reserved fields set to 1
+			},
+			pkt: VP9Packet{
+				B:       true,
+				V:       true,
+				NS:      1,
+				Y:       false,
+				G:       false,
+				NG:      0,
+				Payload: []byte{},
+			},
+		},
+		"ScalabilityStructure_ShortPacket0": {
+			b:   []byte{0x0A, 0x10},
+			err: errShortPacket,
+		},
 		"ScalabilityMissingWidth": {
 			b:   []byte("200"),
 			err: errShortPacket,


### PR DESCRIPTION
Rebase our patches on the latest upstream.

@cptpcrd had added these two patches:

1. [Add missing bounds checks](https://github.com/pion/rtp/commit/f406d45e2859822a0a8315912917b1f4cfbba2f3). [Upstream had a fix for this issue,](https://github.com/pion/rtp/commit/0aced6a2b19ae631ba57335a8bd344d76e609c45) so I skipped this one

2. [Fixing parsing of G bit](https://github.com/pion/rtp/commit/567aefb3c985a3075eccf56f04af1e4092d4593c) - Applied cleanly


Commits added:
- Update CI configs to v0.8.1
- Fix parsing of VP8 packets with degenerate header
- Update CI configs to v0.9.0
- Update CI configs to v0.10.2
- Update CI configs to v0.10.3
- Fix multiple crashes when using VP9 depacketizer
- Fix compatibility with gofmt
- Fix errShortPacket with H264 EOS NALUs
- Cleanup common sections in README
- Update AUTHORS.txt
- Harmonize sections in README
- Update CI configs to v0.10.7
- Make repo REUSE compliant
- Fix golangci-lint warnings
- Update CI configs to v0.10.8
- Update CI configs to v0.10.9
- Revert to 4e87540 (last commit before v2)
- Update CI configs to v0.5.4
- Make VP8 PictureID optional
- Update CI configs to v0.5.6
- Add Z bit to VP9 unmarshaller
- Update CI configs to v0.5.9
- Implement a H265/HEVC packet decoder
- Make MTU a uint16
- Pack SPS and PPS in one STAP-A packet
- Implement partition head in Depacketizer
- Fix unmarshal of packets with padding
- Update CI configs to v0.6.0
- Add PaddingSize to rtp.Packet
- Update CI configs to v0.6.2
- Replace <= with == since mtu cannot be negative
- Update CI configs to v0.6.4
- Adds zero-copy header extensions
- Add IsPartitionHead and IsPartitionTail to H265
- Update CI configs to v0.6.6
- Update CI configs to v0.6.7
- Update CI configs to v0.6.8
- Remove pointer from constant functions
- Add AV1 Support
- Fix AV1 /v2 imports
- Move AV1 Frame to new frame pkg
- Add bounds check to AV1 Frame
- Update CI configs to v0.7.0
- Update CI configs to v0.7.1
- Update CI configs to v0.7.2
- Update CI configs to v0.6.9
- Set CSRC as a empty (not nil) slice by default
- Add experimental header extensions
- Fix multiple crashes when using VP9 depacketizer
- Fix parsing of VP8 packets with degenerate header
- Fix compatibility with gofmt
- Fix errShortPacket with H264 EOS NALUs
- Cleanup common sections in README
- Update AUTHORS.txt
- Harmonize sections in README
- Update CI configs to v0.10.7
- Make repo REUSE compliant
- Fix golangci-lint warnings
- Update CI configs to v0.10.8
- Update CI configs to v0.10.9
- Sync asset files with .goassets
- Minimize changes
- Implement packet clone method
- Fix Packet.Raw population
- Bump Go version
- Fix API breakage on Header.Unmarshal
- Update AUTHORS.txt
- Update AUTHORS.txt
- Add non-breaking version of #160
- Readd non-breaking version of #119
- Update AV1 Payloader to work with libwebrtc
- Replace symlinked license file with copy to fix godoc
- Fix race condition in Packet.MarshalTo()
- Update CI configs to v0.10.11
- Move pkg into codecs/av1
- Optimize the performance of H264 packaging
- Remove redundant state in H264 Packetization
- Combine OneByte and TwoByte extension parsing
- Remove 'Generate Authors' workflow
- Update CI configs to v0.11.0
- Update CI configs to v0.11.3
- Add VLA extention header parser
- Fix a bug in AbsCpatureTimeExtension
- Fix broken link in README.md
- Add static RTP PayloadTypes as a constant
- Add padding support to Packetizer
- Update CI configs to v0.11.4
- Fix out of range access in VP8 Unmarshal
- Update CI configs to v0.11.7
- Update CI configs to v0.11.12
- Convert H264Packet.doPackaging to append style
- Add SetZeroAllocation
- Add ZeroAllocation support to AV1Packet
- Add tests for SetZeroAllocation
- Fix VP9 decoding on iOS
- Fix RTP padding length validation
- Add an index check to prevent out of index
- Add test case for broken second nalu in STAP-A
- Fix rare SRTP loss decode failure
- Update CI configs to v0.11.15
- Update go.mod version to 1.20
- Fix parsing of G bit in VP9 scalability structure
